### PR TITLE
Delete .npmrc

### DIFF
--- a/iot-bootstrap-scripts/.npmrc
+++ b/iot-bootstrap-scripts/.npmrc
@@ -1,1 +1,0 @@
-@sap:registry=https://npm.sap.com


### PR DESCRIPTION
npm.sap.com is deprecated and with this file we get the error:
> npm WARN registry Unexpected warning for https://npm.sap.com: Miscellaneous Warning CERT_HAS_EXPIRED: request to https://npm.sap.com/@sap%2fxsenv failed, reason: certificate has expired
> npm WARN registry Using stale data from https://npm.sap.com due to a request error during revalidation.
> npm ERR! code CERT_HAS_EXPIRED
> npm ERR! errno CERT_HAS_EXPIRED
> npm ERR! request to https://npm.sap.com/@sap%2fxssec failed, reason: certificate has expired